### PR TITLE
Fix regex in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or in your `jest.config.js` file:
 ```js
 module.exports = {
   transform: {
-    "^\\.(gql|graphql)$": "@jagi/jest-transform-graphql"
+    "\\.(gql|graphql)$": "@jagi/jest-transform-graphql"
     /* ... */
   }
   /* ... */


### PR DESCRIPTION
Remove the `^` anchor at the start of the `jest.config.js` regex.